### PR TITLE
Refactor simulator interface and remove matrix handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,16 @@
-.Phony: all
+.PHONY: all
 all: userqasm.so main
 
-userqasm.so: userqasm.cpp qasm.hpp qcs.hpp math.hpp math_type.hpp
+userqasm.so: userqasm.cpp qasm.hpp qcs.hpp
 	$(CXX) -fPIC -shared -std=c++11 userqasm.cpp -o userqasm.so
 
-main: main.cpp qcs.cpp qasm.cpp qasm.hpp qcs.hpp math.hpp math_type.hpp
+main: main.cpp qcs.cpp qasm.cpp qasm.hpp qcs.hpp
 	$(CXX) -std=c++11 -rdynamic main.cpp qcs.cpp qasm.cpp -o main
 
-.Phony: run
+.PHONY: run
 run: all
 	./main
 
-
-.Phony: clean
+.PHONY: clean
 clean:
 	$(RM) main userqasm.so

--- a/qasm.hpp
+++ b/qasm.hpp
@@ -2,10 +2,8 @@
 #include <vector>
 #include <cassert>
 
-#include "math_type.hpp"
-
 namespace qcs{
-    struct simulator;
+    class simulator;
 }
 
 namespace qasm
@@ -69,8 +67,6 @@ namespace qasm
         builder negctrl(int N = 1);
 
     private:
-        void dispatch(int tgt, const math::matrix_t &m, const std::vector<int> &pcs, const std::vector<int> &ncs) const;
-
         qcs::simulator *simulator_ = nullptr;
         int next_id_ = 0;
         friend class builder;
@@ -104,13 +100,17 @@ namespace qasm
         {
             POS_CTRL,
             NEG_CTRL,
-            MATRIX,
             POW,
-            INV
+            INV,
+            HADAMARD,
+            U4
         } kind;
-        math::matrix_t mat{};
+        double theta = 0;
+        double phi = 0;
+        double lambda = 0;
+        double gamma = 0;
         double val = 1;
-        explicit token(kind_t k) : kind(k), mat(), val(1) {}
+        explicit token(kind_t k) : kind(k) {}
     };
 
     /*-------------------------------------------------------
@@ -154,7 +154,6 @@ namespace qasm
             append_args(out, std::forward<Rest>(rest)...);
         }
 
-        void dispatch(int tgt, const math::matrix_t &m, const std::vector<int> &pcs, const std::vector<int> &ncs) const;
     };
 
 } // namespace qasm

--- a/qcs.cpp
+++ b/qcs.cpp
@@ -1,40 +1,67 @@
 #include "qcs.hpp"
 #include <cstdio>
+#include <algorithm>
 
-void qcs::simulator::alloc_qubit(int n)
-{
-    fprintf(stderr, "[qubit declare] %d\n", n);
+namespace qcs {
+
+struct simulator_core {};
+
+simulator::simulator() : core(nullptr), num_qubits(0) {}
+
+void simulator::setup() {}
+
+void simulator::dispose() {}
+
+int simulator::get_num_procs() { return 1; }
+
+int simulator::get_proc_num() { return 0; }
+
+void simulator::promise_qubits(int n) {
+    num_qubits = std::max(num_qubits, n);
+    fprintf(stderr, "[promise_qubits] %d\n", n);
 }
 
-void qcs::simulator::gate_matrix(math::matrix_t matrix, int tgt, int const *pc_list, int num_pcs, int const *nc_list, int num_ncs)
-{
-    fprintf(stderr, "gate matrix={");
-#pragma unroll
-    for (int i = 0; i < 4; ++i)
-    {
-        fprintf(stderr, "{%lf, %lf}", matrix[i].real(), matrix[i].imag());
-        if (i < 3)
-        {
-            fprintf(stderr, ", ");
-        }
-    }
-    fprintf(stderr, "} tgt=%d pc={", tgt);
-    for (int pc_num = 0; pc_num < num_pcs; ++pc_num)
-    {
-        fprintf(stderr, "%d", pc_list[pc_num]);
-        if (pc_num < num_pcs - 1)
-        {
-            fprintf(stderr, ", ");
-        }
-    }
-    fprintf(stderr, "} nc={");
-    for (int nc_num = 0; nc_num < num_ncs; ++nc_num)
-    {
-        fprintf(stderr, "%d", nc_list[nc_num]);
-        if (nc_num < num_ncs - 1)
-        {
-            fprintf(stderr, ", ");
-        }
-    }
-    fprintf(stderr, "}\n");
+void simulator::ensure_qubits_allocated() {}
+
+void simulator::reset() {}
+
+void simulator::set_zero_state() {}
+
+void simulator::set_sequential_state() {}
+
+void simulator::set_flat_state() {}
+
+void simulator::set_entangled_state() {}
+
+void simulator::set_random_state() {}
+
+void simulator::hadamard(int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
+    hadamard_pow(1.0, target, std::move(ncs), std::move(pcs));
 }
+
+void simulator::hadamard_pow(double exponent, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
+    fprintf(stderr, "[hadamard_pow] exp=%lf tgt=%d\n", exponent, target);
+}
+
+void simulator::gate_x(double exponent, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
+    gate_x_pow(exponent, target, std::move(ncs), std::move(pcs));
+}
+
+void simulator::gate_x_pow(double exponent, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
+    fprintf(stderr, "[gate_x_pow] exp=%lf tgt=%d\n", exponent, target);
+}
+
+void simulator::gate_u4(double th, double ph, double la, double ga, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
+    gate_u4_pow(th, ph, la, ga, 1.0, target, std::move(ncs), std::move(pcs));
+}
+
+void simulator::gate_u4_pow(double th, double ph, double la, double ga, double exp, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
+    fprintf(stderr, "[gate_u4_pow] th=%lf ph=%lf la=%lf ga=%lf exp=%lf tgt=%d\n", th, ph, la, ga, exp, target);
+}
+
+int simulator::measure(int qubit_num) {
+    fprintf(stderr, "[measure] %d\n", qubit_num);
+    return 0;
+}
+
+} // namespace qcs

--- a/qcs.hpp
+++ b/qcs.hpp
@@ -1,11 +1,36 @@
 #pragma once
-
-#include "math.hpp"
+#include <vector>
 
 namespace qcs {
-    struct simulator {
-        void alloc_qubit(int n);
-        void gate_matrix(math::matrix_t matrix, int tgt, int const* pc_list,
-                          int num_pcs, int const* nc_list, int num_ncs);
+    struct simulator_core;
+    class simulator {
+    private:
+        simulator_core* core;
+        int num_qubits;
+        void ensure_qubits_allocated();
+    public:
+        simulator();
+        void setup();
+        void dispose();
+
+        int get_num_procs();
+        int get_proc_num();
+
+        void promise_qubits(int num_qubits);
+
+        void reset();
+        void set_zero_state();
+        void set_sequential_state();
+        void set_flat_state();
+        void set_entangled_state();
+        void set_random_state();
+
+        void hadamard(int target_qubit_num, std::vector<int>&& negctrl_qubit_num_list, std::vector<int>&& ctrl_qubit_num_list);
+        void hadamard_pow(double exponent, int target_qubit_num, std::vector<int>&& negctrl_qubit_num_list, std::vector<int>&& ctrl_qubit_num_list);
+        void gate_x(double exponent, int target_qubit_num, std::vector<int>&& negctrl_qubit_num_list, std::vector<int>&& ctrl_qubit_num_list);
+        void gate_x_pow(double exponent, int target_qubit_num, std::vector<int>&& negctrl_qubit_num_list, std::vector<int>&& ctrl_qubit_num_list);
+        void gate_u4(double theta, double phi, double lambda, double gamma, int target_qubit_num, std::vector<int>&& negctrl_qubit_num_list, std::vector<int>&& ctrl_qubit_num_list);
+        void gate_u4_pow(double theta, double phi, double lambda, double gamma, double exponent, int target_qubit_num, std::vector<int>&& negctrl_qubit_num_list, std::vector<int>&& ctrl_qubit_num_list);
+        int measure(int qubit_num);
     };
 }


### PR DESCRIPTION
## Summary
- Replace legacy matrix-based simulator interface with explicit gate functions and qubit promises
- Refactor QASM builder to dispatch Hadamard and U4 gates directly to the simulator without matrix math
- Simplify build script and update qubit allocation to use new simulator API

## Testing
- `make clean`
- `make all`
- `./main`


------
https://chatgpt.com/codex/tasks/task_e_6893014cb5b4832b8733df6c6add9d17