### PR TITLE
Support classical bits, cu gate, reset and measure

### DIFF
--- a/qcs.cpp
+++ b/qcs.cpp
@@ -6,6 +6,11 @@ void qcs::simulator::alloc_qubit(int n)
     fprintf(stderr, "[qubit declare] %d\n", n);
 }
 
+void qcs::simulator::clalloc(int n)
+{
+    fprintf(stderr, "[clbit declare] %d\n", n);
+}
+
 void qcs::simulator::gate_matrix(math::matrix_t matrix, int tgt, int const *pc_list, int num_pcs, int const *nc_list, int num_ncs)
 {
     fprintf(stderr, "gate matrix={");
@@ -37,4 +42,48 @@ void qcs::simulator::gate_matrix(math::matrix_t matrix, int tgt, int const *pc_l
         }
     }
     fprintf(stderr, "}\n");
+}
+
+void qcs::simulator::gate_u4(math::matrix_t matrix, int tgt, int const *pc_list, int num_pcs, int const *nc_list, int num_ncs)
+{
+    fprintf(stderr, "gate_u4 matrix={");
+#pragma unroll
+    for (int i = 0; i < 4; ++i)
+    {
+        fprintf(stderr, "{%lf, %lf}", matrix[i].real(), matrix[i].imag());
+        if (i < 3)
+        {
+            fprintf(stderr, ", ");
+        }
+    }
+    fprintf(stderr, "} tgt=%d pc={", tgt);
+    for (int pc_num = 0; pc_num < num_pcs; ++pc_num)
+    {
+        fprintf(stderr, "%d", pc_list[pc_num]);
+        if (pc_num < num_pcs - 1)
+        {
+            fprintf(stderr, ", ");
+        }
+    }
+    fprintf(stderr, "} nc={");
+    for (int nc_num = 0; nc_num < num_ncs; ++nc_num)
+    {
+        fprintf(stderr, "%d", nc_list[nc_num]);
+        if (nc_num < num_ncs - 1)
+        {
+            fprintf(stderr, ", ");
+        }
+    }
+    fprintf(stderr, "}\n");
+}
+
+void qcs::simulator::reset(int qubit)
+{
+    fprintf(stderr, "reset %d\n", qubit);
+}
+
+int qcs::simulator::measure(int qubit)
+{
+    fprintf(stderr, "measure %d\n", qubit);
+    return 0;
 }

--- a/qcs.hpp
+++ b/qcs.hpp
@@ -5,7 +5,12 @@
 namespace qcs {
     struct simulator {
         void alloc_qubit(int n);
+        void clalloc(int n);
         void gate_matrix(math::matrix_t matrix, int tgt, int const* pc_list,
                           int num_pcs, int const* nc_list, int num_ncs);
+        void gate_u4(math::matrix_t matrix, int tgt, int const* pc_list,
+                     int num_pcs, int const* nc_list, int num_ncs);
+        void reset(int qubit);
+        int measure(int qubit);
     };
 }

--- a/userqasm.cpp
+++ b/userqasm.cpp
@@ -6,16 +6,14 @@ public:
     void circuit() {
         using namespace qasm;
 
-        qubits q1 = qalloc(8);
-        qubits q2 = qalloc(8);
-        (negctrl(2) * ctrl(2) * h())(q1[0], q1[slice(1, 2)], q1[{3, 4}]);
-        u(0, 0, 1.0)(q1[0]);
-        u(0, 0, 0.5)(q1[0]);
-        (ctrl(2) * pow(0.5) * u(0, 0, 1.0))(q1[0], q1[1], q1[2]);
-        (inv() * h())(q1[0]);
-        (ctrl(2) * h())(q2[0], q2[1], q2[2]);
+        qubits q = qalloc(2);
+        clbits c = clalloc(2);
 
+        cu(1.0, 0.0, 0.0, 1.0)(q[0]);
+        reset(q);
+        measure(q);
     }
 };
 
 extern "C" qasm::qasm* constructor() { return new userqasm(); }
+


### PR DESCRIPTION
## Summary
- add classical bit allocation, reset, and measurement hooks
- support controlled-U (`cu`) gate via simulator `gate_u4`
- update example circuit to use new features

## Testing
- `make all`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68932a836c30832bb594ddc95e9d427a