### PR TITLE
Add classical bit support and controlled-U gate

### DIFF
--- a/qasm.cpp
+++ b/qasm.cpp
@@ -144,6 +144,16 @@ builder qasm::u(double th, double ph, double la) {
     return builder(*this, tk);
 }
 
+builder qasm::cu(double th, double ph, double la, double ga) {
+    token ctrl{token::POS_CTRL};
+    token u4{token::U4};
+    u4.theta = th;
+    u4.phi = ph;
+    u4.lambda = la;
+    u4.gamma = ga;
+    return builder(*this, ctrl) * builder(*this, u4);
+}
+
 builder qasm::pow(double exp) {
     token tk{token::POW};
     tk.val = exp;
@@ -179,6 +189,42 @@ builder qasm::negctrl(int N) {
 
 qubits qasm::qalloc(int n) {
     return qubits(*this, n);
+}
+
+bit qasm::clalloc(int n) {
+    return bit(n);
+}
+
+void qasm::reset(const qubits &qs) {
+    assert(simulator_ && "simulator not registered");
+    for (int i = 0; i < qs.size_; ++i) {
+        simulator_->reset(qs.base_ + i);
+    }
+}
+
+void qasm::reset(const indices_t &qs) {
+    assert(simulator_ && "simulator not registered");
+    for (int q : qs.values) {
+        simulator_->reset(q);
+    }
+}
+
+std::vector<int> qasm::measure(const qubits &qs) {
+    indices_t idx;
+    for (int i = 0; i < qs.size_; ++i) {
+        idx.values.push_back(qs.base_ + i);
+    }
+    return measure(idx);
+}
+
+std::vector<int> qasm::measure(const indices_t &qs) {
+    assert(simulator_ && "simulator not registered");
+    std::vector<int> out;
+    out.reserve(qs.values.size());
+    for (int q : qs.values) {
+        out.push_back(simulator_->measure(q));
+    }
+    return out;
 }
 
 void qasm::circuit() {

--- a/qcs.cpp
+++ b/qcs.cpp
@@ -25,6 +25,10 @@ void simulator::ensure_qubits_allocated() {}
 
 void simulator::reset() {}
 
+void simulator::reset(int qubit_num) {
+    fprintf(stderr, "[reset] %d\n", qubit_num);
+}
+
 void simulator::set_zero_state() {}
 
 void simulator::set_sequential_state() {}

--- a/qcs.hpp
+++ b/qcs.hpp
@@ -19,6 +19,7 @@ namespace qcs {
         void promise_qubits(int num_qubits);
 
         void reset();
+        void reset(int qubit_num);
         void set_zero_state();
         void set_sequential_state();
         void set_flat_state();

--- a/userqasm.cpp
+++ b/userqasm.cpp
@@ -3,7 +3,7 @@
 class userqasm : public qasm::qasm
 {
 public:
-    bit clbit;
+    ::qasm::bit clbit;
     void circuit() {
         using namespace qasm;
 
@@ -19,7 +19,7 @@ public:
         (inv() * h())(q1[0]);
         (ctrl(2) * h())(q2[0], q2[1], q2[2]);
 
-        clbit[slice(0, 7)] = measure(q1[slice(0, 8)]);
+        clbit[slice(0, 7)] = measure(q1[slice(0, 7)]);
         clbit[{8, 9}] = measure(q2[{0, 1}]);
 
     }


### PR DESCRIPTION
## Summary
- Support classical registers via new `bit` type and `clalloc`
- Add `cu` builder mapping to `gate_u4` and expose reset/measure helpers
- Extend simulator with single-qubit `reset`

## Testing
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_68932c6d8458832bb9ea0082b8bdd470