### PR TITLE
Enable assigning measurement results directly to bit

### DIFF
--- a/include/qasm/qasm.hpp
+++ b/include/qasm/qasm.hpp
@@ -146,6 +146,15 @@ namespace qasm
             return indices_proxy(*this, std::move(idx));
         }
 
+        bit &operator=(const std::vector<int> &vals)
+        {
+            for (std::size_t i = 0; i < values_.size() && i < vals.size(); ++i)
+            {
+                values_[i] = vals[i];
+            }
+            return *this;
+        }
+
     private:
         std::vector<int> values_;
         friend class qasm;

--- a/src/userqasm_002.cpp
+++ b/src/userqasm_002.cpp
@@ -15,7 +15,7 @@ public:
         for(int qubit_num = 0; qubit_num < num_qubits; qubit_num++) {
             (ctrl(1) * h())(q[0], q[qubit_num]);
         }
-        clbit[slice(0, 13)] = measure(q);
+        clbit = measure(q);
     }
 };
 


### PR DESCRIPTION
## Summary
- add `bit` assignment operator from measurement vectors
- simplify sample circuit to capture measurements without slicing

## Testing
- `make all`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68933b068ec0832bbb6bb0b0b0ed0f52