### PR TITLE
Enable range-based iteration for qasm slice

### DIFF
--- a/include/qasm/qasm.hpp
+++ b/include/qasm/qasm.hpp
@@ -13,6 +13,18 @@ namespace qasm
     {
         int first;
         int last;
+
+        struct iterator
+        {
+            int value;
+            explicit iterator(int v) : value(v) {}
+            int operator*() const { return value; }
+            iterator &operator++() { ++value; return *this; }
+            bool operator!=(const iterator &other) const { return value != other.value; }
+        };
+
+        iterator begin() const { return iterator(first); }
+        iterator end() const { return iterator(last + 1); }
     };
 
     slice_t slice(int first, int last);

--- a/src/userqasm_002.cpp
+++ b/src/userqasm_002.cpp
@@ -12,7 +12,7 @@ public:
         reset(q);
         
         h()(q[0]);
-        for(int qubit_num = 0; qubit_num < num_qubits; qubit_num++) {
+        for (int qubit_num : slice(0, num_qubits - 1)) {
             (ctrl(1) * h())(q[0], q[qubit_num]);
         }
         clbit = measure(q);


### PR DESCRIPTION
## Summary
- allow `qasm::slice_t` to be used in range-based for loops by adding an iterator with `begin`/`end`
- update example circuit to demonstrate range-based for with `slice`

## Testing
- `make clean && make all`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68933c2fd254832baa9706d01d75917a