### PR TITLE
Add ctrl/negctrl debug output for gates

### DIFF
--- a/qcs/src/qcs.cpp
+++ b/qcs/src/qcs.cpp
@@ -6,6 +6,18 @@ namespace qcs {
 
 struct simulator_core {};
 
+static void print_ctrls(const std::vector<int>& ncs, const std::vector<int>& pcs) {
+    fprintf(stderr, " negctrl=[");
+    for (size_t i = 0; i < ncs.size(); ++i) {
+        fprintf(stderr, "%s%d", i ? "," : "", ncs[i]);
+    }
+    fprintf(stderr, "] ctrl=[");
+    for (size_t i = 0; i < pcs.size(); ++i) {
+        fprintf(stderr, "%s%d", i ? "," : "", pcs[i]);
+    }
+    fprintf(stderr, "]");
+}
+
 simulator::simulator() : core(nullptr), num_qubits(0) {}
 
 void simulator::setup() {}
@@ -44,7 +56,9 @@ void simulator::hadamard(int target, std::vector<int>&& ncs, std::vector<int>&& 
 }
 
 void simulator::hadamard_pow(double exponent, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
-    fprintf(stderr, "[hadamard_pow] exp=%lf tgt=%d\n", exponent, target);
+    fprintf(stderr, "[hadamard_pow] exp=%lf tgt=%d", exponent, target);
+    print_ctrls(ncs, pcs);
+    fprintf(stderr, "\n");
 }
 
 void simulator::gate_x(double exponent, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
@@ -52,7 +66,9 @@ void simulator::gate_x(double exponent, int target, std::vector<int>&& ncs, std:
 }
 
 void simulator::gate_x_pow(double exponent, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
-    fprintf(stderr, "[gate_x_pow] exp=%lf tgt=%d\n", exponent, target);
+    fprintf(stderr, "[gate_x_pow] exp=%lf tgt=%d", exponent, target);
+    print_ctrls(ncs, pcs);
+    fprintf(stderr, "\n");
 }
 
 void simulator::gate_u4(double th, double ph, double la, double ga, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
@@ -60,7 +76,9 @@ void simulator::gate_u4(double th, double ph, double la, double ga, int target, 
 }
 
 void simulator::gate_u4_pow(double th, double ph, double la, double ga, double exp, int target, std::vector<int>&& ncs, std::vector<int>&& pcs) {
-    fprintf(stderr, "[gate_u4_pow] th=%lf ph=%lf la=%lf ga=%lf exp=%lf tgt=%d\n", th, ph, la, ga, exp, target);
+    fprintf(stderr, "[gate_u4_pow] th=%lf ph=%lf la=%lf ga=%lf exp=%lf tgt=%d", th, ph, la, ga, exp, target);
+    print_ctrls(ncs, pcs);
+    fprintf(stderr, "\n");
 }
 
 int simulator::measure(int qubit_num) {


### PR DESCRIPTION
## Summary
- log negative and positive control qubits for gate operations in qcs simulator

## Testing
- `make`
- `make run`

------
https://chatgpt.com/codex/tasks/task_e_689341c46d28832b806c6efe121dea15