### PR TITLE
Enable range-based iteration for qasm::set

### DIFF
--- a/include/qasm/qasm.hpp
+++ b/include/qasm/qasm.hpp
@@ -33,6 +33,10 @@ namespace qasm
     {
         std::vector<int> indices;
         set(std::initializer_list<int> lst);
+        std::vector<int>::iterator begin() { return indices.begin(); }
+        std::vector<int>::iterator end() { return indices.end(); }
+        std::vector<int>::const_iterator begin() const { return indices.begin(); }
+        std::vector<int>::const_iterator end() const { return indices.end(); }
     };
 
     struct indices_t


### PR DESCRIPTION
## Summary
- support range-based for loops by exposing iterators from `qasm::set`

## Testing
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_6893448b0608832b8564da258cd48d13