### PR TITLE
Refactor qubits to track index lists and relax concat requirements

### DIFF
--- a/include/qasm/qasm.hpp
+++ b/include/qasm/qasm.hpp
@@ -191,7 +191,7 @@ namespace qasm
     };
 
     /*-------------------------------------------------------
-     * 量子レジスタ（連番 ID を払い出すだけ）
+     * 量子レジスタ（ID のリストを保持）
      *------------------------------------------------------*/
     class qubits
     {
@@ -203,10 +203,9 @@ namespace qasm
         indices_t operator[](std::initializer_list<int> lst) const;
 
     private:
-        qubits(qasm &ctx, int base, int size);
+        qubits(qasm &ctx, std::vector<int> idx);
         qasm &ctx_;
-        int base_;
-        int size_;
+        std::vector<int> indices_;
         friend class qasm;
         friend qubits concat(const qubits &lhs, const qubits &rhs);
     };


### PR DESCRIPTION
## Summary
- store explicit index lists in `qasm::qubits`
- allow `concat` to merge non-contiguous qubit groups
- adjust `reset`/`measure` to iterate over stored indices

## Testing
- `make all`
- `make run`


------
https://chatgpt.com/codex/tasks/task_e_68934d212ca8832bac7e29c127ab7240